### PR TITLE
Update pom + docs to compile on JDK 9 and newer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ __Pull requests are encouraged!__
 
 ### Tools
 
-1.  Install [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+1.  Install [JDK version 8 or newer](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 1.  Install Maven (for
     [windows](https://maven.apache.org/guides/getting-started/windows-prerequisites.html),
     [mac](http://tostring.me/151/installing-maven-on-os-x/),

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
                 <configuration>
                   <source>1.8</source>
                   <target>1.8</target>
+                  <release>8</release>
                   <includes>
                     <!-- This pattern is brittle; we would prefer to filter on the directory
                          but that seems to be unavailable to us. -->


### PR DESCRIPTION
Many users have JDK 9, 10 and 11 installed, and the current POM fails under the newer platform versions. This change fixes that.